### PR TITLE
Added the ability to save RAMPZ and EIND registers (Atmega2560 has it)

### DIFF
--- a/arduino.DuinOS/DuinOS/port.c
+++ b/arduino.DuinOS/DuinOS/port.c
@@ -119,7 +119,56 @@ extern volatile tskTCB * volatile pxCurrentTCB;
  * The interrupts will have been disabled during the call to portSAVE_CONTEXT()
  * so we need not worry about reading/writing to the stack pointer. 
  */
-
+#if defined(__AVR_ATmega2560__)
+#define portSAVE_CONTEXT()									\
+	asm volatile (	"push	r0						\n\t"	\
+					"in		r0, __SREG__			\n\t"	\
+					"cli							\n\t"	\
+					"push	r0						\n\t"	\
+					"push	r0						\n\t"	\
+					"in		r0, 0x3b				\n\t"	\
+					"push	r0						\n\t"	\
+					"in		r0, 0x3c				\n\t"	\
+					"push	r1						\n\t"	\
+					"clr	r1						\n\t"	\
+					"push	r2						\n\t"	\
+					"push	r3						\n\t"	\
+					"push	r4						\n\t"	\
+					"push	r5						\n\t"	\
+					"push	r6						\n\t"	\
+					"push	r7						\n\t"	\
+					"push	r8						\n\t"	\
+					"push	r9						\n\t"	\
+					"push	r10						\n\t"	\
+					"push	r11						\n\t"	\
+					"push	r12						\n\t"	\
+					"push	r13						\n\t"	\
+					"push	r14						\n\t"	\
+					"push	r15						\n\t"	\
+					"push	r16						\n\t"	\
+					"push	r17						\n\t"	\
+					"push	r18						\n\t"	\
+					"push	r19						\n\t"	\
+					"push	r20						\n\t"	\
+					"push	r21						\n\t"	\
+					"push	r22						\n\t"	\
+					"push	r23						\n\t"	\
+					"push	r24						\n\t"	\
+					"push	r25						\n\t"	\
+					"push	r26						\n\t"	\
+					"push	r27						\n\t"	\
+					"push	r28						\n\t"	\
+					"push	r29						\n\t"	\
+					"push	r30						\n\t"	\
+					"push	r31						\n\t"	\
+					"lds	r26, pxCurrentTCB		\n\t"	\
+					"lds	r27, pxCurrentTCB + 1	\n\t"	\
+					"in		r0, 0x3d				\n\t"	\
+					"st		x+, r0					\n\t"	\
+					"in		r0, 0x3e				\n\t"	\
+					"st		x+, r0					\n\t"	\
+				);
+#else
 #define portSAVE_CONTEXT()									\
 	asm volatile (	"push	r0						\n\t"	\
 					"in		r0, __SREG__			\n\t"	\
@@ -164,12 +213,14 @@ extern volatile tskTCB * volatile pxCurrentTCB;
 					"in		r0, 0x3e				\n\t"	\
 					"st		x+, r0					\n\t"	\
 				);
+#endif
 
 /* 
  * Opposite to portSAVE_CONTEXT().  Interrupts will have been disabled during
  * the context save so we can write to the stack pointer. 
  */
 
+#if defined(__AVR_ATmega2560__)
 #define portRESTORE_CONTEXT()								\
 	asm volatile (	"lds	r26, pxCurrentTCB		\n\t"	\
 					"lds	r27, pxCurrentTCB + 1	\n\t"	\
@@ -209,9 +260,61 @@ extern volatile tskTCB * volatile pxCurrentTCB;
 					"pop	r2						\n\t"	\
 					"pop	r1						\n\t"	\
 					"pop	r0						\n\t"	\
+					"out	0x3c, r0				\n\t"	\
+					"pop	r0						\n\t"	\
+					"out	0x3b, r0				\n\t"	\
+					"pop	r0						\n\t"	\
 					"out	__SREG__, r0			\n\t"	\
 					"pop	r0						\n\t"	\
 				);
+#else
+#define portRESTORE_CONTEXT()								\
+	asm volatile (	"lds	r26, pxCurrentTCB		\n\t"	\
+					"lds	r27, pxCurrentTCB + 1	\n\t"	\
+					"ld		r28, x+					\n\t"	\
+					"out	__SP_L__, r28			\n\t"	\
+					"ld		r29, x+					\n\t"	\
+					"out	__SP_H__, r29			\n\t"	\
+					"pop	r31						\n\t"	\
+					"pop	r30						\n\t"	\
+					"pop	r29						\n\t"	\
+					"pop	r28						\n\t"	\
+					"pop	r27						\n\t"	\
+					"pop	r26						\n\t"	\
+					"pop	r25						\n\t"	\
+					"pop	r24						\n\t"	\
+					"pop	r23						\n\t"	\
+					"pop	r22						\n\t"	\
+					"pop	r21						\n\t"	\
+					"pop	r20						\n\t"	\
+					"pop	r19						\n\t"	\
+					"pop	r18						\n\t"	\
+					"pop	r17						\n\t"	\
+					"pop	r16						\n\t"	\
+					"pop	r15						\n\t"	\
+					"pop	r14						\n\t"	\
+					"pop	r13						\n\t"	\
+					"pop	r12						\n\t"	\
+					"pop	r11						\n\t"	\
+					"pop	r10						\n\t"	\
+					"pop	r9						\n\t"	\
+					"pop	r8						\n\t"	\
+					"pop	r7						\n\t"	\
+					"pop	r6						\n\t"	\
+					"pop	r5						\n\t"	\
+					"pop	r4						\n\t"	\
+					"pop	r3						\n\t"	\
+					"pop	r2						\n\t"	\
+					"pop	r1						\n\t"	\
+					"pop	r0						\n\t"	\
+					"out	0x3c, r0				\n\t"	\
+					"pop	r0						\n\t"	\
+					"out	0x3b, r0				\n\t"	\
+					"pop	r0						\n\t"	\
+					"out	__SREG__, r0			\n\t"	\
+					"pop	r0						\n\t"	\
+				);
+#endif
 
 /*-----------------------------------------------------------*/
 
@@ -226,9 +329,10 @@ static void prvSetupTimerInterrupt( void );
  */
 portSTACK_TYPE *pxPortInitialiseStack( portSTACK_TYPE *pxTopOfStack, pdTASK_CODE pxCode, void *pvParameters )
 {
-        /* ATmega2560 DuinOS port by SkyWodd */
 #if defined(__AVR_ATmega2560__)
-        unsigned portLONG usAddress; // ATMega2560 have 22bit Program Counter register
+        /* ATmega2560 DuinOS port by SkyWodd 
+        * Corrected by NiesteSzeck*/
+        unsigned portLONG usAddress; // ATMega2560 have 17bit Program Counter register
 #else
         unsigned portSHORT usAddress; // over ATmega have 16bit Program Counter register
 #endif
@@ -286,6 +390,18 @@ portSTACK_TYPE *pxPortInitialiseStack( portSTACK_TYPE *pxTopOfStack, pdTASK_CODE
 	*pxTopOfStack = portFLAGS_INT_ENABLED;
 	pxTopOfStack--;
 
+#if defined(__AVR_ATmega2560__)
+
+	/* The Atmega2560 has two more register that we are saving
+	* The EIND and AMPZ and wea re going to initialize 
+	* this registers to 0 (default initial values)
+	*/
+	*pxTopOfStack = ( portSTACK_TYPE ) 0x00;	/* EIND */
+	pxTopOfStack--;
+	*pxTopOfStack = ( portSTACK_TYPE ) 0x00;	/* RAMPZ */
+	pxTopOfStack--;
+
+#endif
 
 	/* Now the remaining registers.   The compiler expects R1 to be 0. */
 	*pxTopOfStack = ( portSTACK_TYPE ) 0x00;	/* R1 */


### PR DESCRIPTION
Hi Carlos.
I eddited the patch 'cause the Mega2560 has more registers that mus be saved in a context change, here are th corrections
