### PR TITLE
Proposing to clean the file DuinOS.h 'cause the lowtext attribute is in ...

### DIFF
--- a/arduino.DuinOS/DuinOS.h
+++ b/arduino.DuinOS/DuinOS.h
@@ -35,8 +35,8 @@ extern unsigned portBASE_TYPE mainLoopStackSize;
 #define HIGH_PRIORITY		(tskIDLE_PRIORITY + 2)
 
 #define taskLoop(name) \
-static inline void name##Function() __attribute__((__section__(".lowtext"),__naked__,__always_inline__)); \
-void name##_Task(void *) __attribute__((__section__(".lowtext"))); \
+static inline void name##Function() __attribute__((__section__(".text.lowtext"),__naked__,__always_inline__)); \
+void name##_Task(void *) __attribute__((__section__(".text.lowtext"))); \
 xTaskHandle name; \
 void name##_Task(void *pvParameters)\
 {\
@@ -49,7 +49,7 @@ static inline void name##Function()
 //taskLoop()macro use and reference them:
 #define declareTaskLoop(name)\
 	extern xTaskHandle name;\
-    void name##_Task(void *) __attribute__((__section__(".lowtext")))
+    void name##_Task(void *) __attribute__((__section__(".text.lowtext")))
 
 
 #define createTaskLoop(name, priority)\


### PR DESCRIPTION
Proposing to clean the file DuinOS.h 'cause the lowtext attribute is in macro definition from FreeRTOS on file portmacro.h and here is duplicated
